### PR TITLE
Fix calling wrong variable in RNDeviceHeading.start

### DIFF
--- a/deviceheading.js
+++ b/deviceheading.js
@@ -6,7 +6,7 @@ let listener;
 let _start = RNDeviceHeading.start;
 RNDeviceHeading.start = (updateRate, callback) => {
   if (listener) {
-    DeviceHeading.stop();
+    RNDeviceHeading.stop();
   }
 
   const rnDeviceEventEmitter = new NativeEventEmitter(RNDeviceHeading);


### PR DESCRIPTION
FIX: Nonexistent variable called inside `RNDeviceHeading.start` method.